### PR TITLE
Computing the block offsets instead of split offsets

### DIFF
--- a/dfs-datastores/src/main/java/com/backtype/hadoop/pail/SequenceFileFormat.java
+++ b/dfs-datastores/src/main/java/com/backtype/hadoop/pail/SequenceFileFormat.java
@@ -91,6 +91,7 @@ public class SequenceFileFormat implements PailFormat {
         JobConf conf;
         PailInputSplit split;
         int recordsRead;
+        long currentStartOffset = 0;
         Reporter reporter;
 
         SequenceFileRecordReader<BytesWritable, NullWritable> delegate;
@@ -109,13 +110,25 @@ public class SequenceFileFormat implements PailFormat {
            this.delegate = new SequenceFileRecordReader<BytesWritable, NullWritable>(conf, split);
            BytesWritable dummyValue = new BytesWritable();
            for(int i=0; i<recordsRead; i++) {
+               long posBeforeNext = delegate.getPos();
                delegate.next(dummyValue, NullWritable.get());
+               long posAfterNext = delegate.getPos();
+               checkForOffsetDuringBlockCompression(posBeforeNext, posAfterNext);
            }
         }
 
         private void progress() {
             if(reporter!=null) {
                 reporter.progress();
+            }
+        }
+
+        private void checkForOffsetDuringBlockCompression(long posBeforeReading, long posAfterReading) {
+            if(posAfterReading != posBeforeReading) {
+                recordsRead =0;
+                currentStartOffset = posBeforeReading;
+            } else {
+                recordsRead++;
             }
         }
 
@@ -132,14 +145,15 @@ public class SequenceFileFormat implements PailFormat {
              */
             for(int i=0; i<NUM_TRIES; i++) {
                 try {
-                    long recordStartPos = delegate.getPos();
+                    long posBeforeNext = delegate.getPos();
                     boolean ret = delegate.next(v, NullWritable.get());
-                    recordsRead++;
+                    long posAfterNext = delegate.getPos();
+                    checkForOffsetDuringBlockCompression(posBeforeNext, posAfterNext);
 
                     k.setFullPath(split.getPath().toString());
                     k.setPailRelativePath(split.getPailRelPath());
-                    k.setSplitStartOffset(recordStartPos);
-                    k.setRecordsToSkip(0);
+                    k.setSplitStartOffset(currentStartOffset);
+                    k.setRecordsToSkip(recordsRead);
                     return ret;
                 } catch(EOFException e) {
                     progress();

--- a/dfs-datastores/src/main/java/com/backtype/hadoop/pail/SequenceFileFormat.java
+++ b/dfs-datastores/src/main/java/com/backtype/hadoop/pail/SequenceFileFormat.java
@@ -13,7 +13,6 @@ import org.apache.hadoop.fs.Path;
 import org.apache.hadoop.io.BytesWritable;
 import org.apache.hadoop.io.NullWritable;
 import org.apache.hadoop.io.SequenceFile.CompressionType;
-import org.apache.hadoop.io.Text;
 import org.apache.hadoop.io.compress.BZip2Codec;
 import org.apache.hadoop.io.compress.CompressionCodec;
 import org.apache.hadoop.io.compress.DefaultCodec;
@@ -133,13 +132,14 @@ public class SequenceFileFormat implements PailFormat {
              */
             for(int i=0; i<NUM_TRIES; i++) {
                 try {
+                    long recordStartPos = delegate.getPos();
                     boolean ret = delegate.next(v, NullWritable.get());
                     recordsRead++;
 
                     k.setFullPath(split.getPath().toString());
                     k.setPailRelativePath(split.getPailRelPath());
-                    k.setSplitStartOffset(split.getStart());
-                    k.setRecordsToSkip(recordsRead);
+                    k.setSplitStartOffset(recordStartPos);
+                    k.setRecordsToSkip(0);
                     return ret;
                 } catch(EOFException e) {
                     progress();

--- a/project/build.properties
+++ b/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.12.0
+sbt.version=0.12.4

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.5.3-indix"
+version in ThisBuild := "1.6-pail-test-SNAPSHOT"

--- a/version.sbt
+++ b/version.sbt
@@ -1,1 +1,1 @@
-version in ThisBuild := "1.6-pail-test-SNAPSHOT"
+version in ThisBuild := "1.5.4-indix"


### PR DESCRIPTION
This approach gives you a better visibility to the record boundary. We still need recordsRead field since the actual record offset is impossible to detect when the underlying sequence file is BLOCK compressed.
The current implementation will give you record offsets with recordsRead as 0 when we have RECORD compression / no compression on the sequence file.

EDIT - SBT version upgrade is for IDEA to import the project :)