### PR TITLE
Making renames noop when using S3N scheme

### DIFF
--- a/dfs-datastores/src/main/java/com/backtype/hadoop/pail/Pail.java
+++ b/dfs-datastores/src/main/java/com/backtype/hadoop/pail/Pail.java
@@ -547,7 +547,13 @@ public class Pail<T> extends AbstractPail implements Iterable<T>{
 
     @Override
     protected boolean rename(Path source, Path dest) throws IOException {
-        return _fs.rename(source, dest);
+        // Renames are noop when on S3
+        return isS3FS() || _fs.rename(source, dest);
+    }
+
+    @Override
+    protected boolean isS3FS() {
+        return _fs.getScheme().equals("s3n");
     }
 
     @Override


### PR DESCRIPTION
@sriram-r @vinothkr @gsriram7 @ganeshpraburavi @kishorenc  Please review the changes. 

Context - When we're using S3, we don't need to do worry about inconsistent files being written. The change here is to avoid doing renames where ever possible and making renames a no-op on S3. 

@gsriram7 @ganeshpraburavi Guys I need your help in testing this change. 